### PR TITLE
Update QR Tab's Styling for input boxes.

### DIFF
--- a/src/components/project-tabs/QRTab.jsx
+++ b/src/components/project-tabs/QRTab.jsx
@@ -73,6 +73,7 @@ const QRTab = (props) => {
   // Create QR code link
   const qrCodeLink = `exp://exp.host/@imaginethis/${state.projectID}`;
 
+  lastConversion = "7865"
   // Depending on the status of last conversion show different contents
   if (!lastConversion) {
     return (
@@ -125,25 +126,6 @@ const QRTab = (props) => {
         <Container>
           <Row>
             <Col>
-              <Form
-                onSubmit={sendEmail}
-                className="input-group navbar-group"
-                style={{ margin: "", width: "50%" }}
-              >
-                <InputGroup className="input-group-append">
-                  <FormControl
-                      ref={inputEl}
-                      className="form-control md-4"
-                      aria-describedby="basic-addon1"
-                      placeholder="Enter your Expo account email address"
-                    />
-                  <InputGroup.Append>
-                     <Button type="submit">
-                       Submit
-                     </Button>
-                  </InputGroup.Append>
-                </InputGroup>
-              </Form>
               <ol className="pc-ordered-list">
                 <li>
                   Install the "
@@ -164,6 +146,24 @@ const QRTab = (props) => {
                 <li>A notification will appear saying to open the build in Expo. Click on this.</li>
                 <li>The expo app should then open and the prototype should begin to run on your device.</li>
               </ol>
+              <Form
+                onSubmit={sendEmail}
+                className="input-group pc-input-bar-group"
+              >
+                <InputGroup className="input-group-append">
+                  <FormControl
+                    ref={inputEl}
+                    className="form-control md-4 pc-input-bar"
+                    aria-describedby="basic-addon1"
+                    placeholder="Enter Expo Account Email Address"
+                  />
+                  <InputGroup.Append>
+                    <Button type="submit">
+                      Submit
+                    </Button>
+                  </InputGroup.Append>
+                </InputGroup>
+              </Form>
             </Col>
             <Col xs={3} className="pc-qr-col">
               <a href={qrCodeLink}>

--- a/src/components/project-tabs/QRTab.jsx
+++ b/src/components/project-tabs/QRTab.jsx
@@ -275,7 +275,7 @@ const QRTab = (props) => {
           >
             <InputGroup className="input-group-prepend">
               <FormControl
-                ref={inputEl}
+                // ref={inputEl} Can't have inputEl in both places
                 className="form-control md-4 mobile-input-bar"
                 aria-describedby="basic-addon1"
                 placeholder="Enter Expo Account Email Address"

--- a/src/components/project-tabs/QRTab.jsx
+++ b/src/components/project-tabs/QRTab.jsx
@@ -135,7 +135,7 @@ const QRTab = (props) => {
                 <li>Sign into your Expo account, or create one if you don't already have one.</li>
                 <li>
                   Add yourself to the ImagineThis Expo organisation by entering in your account's
-                  email via the text box above.
+                  email via the text box below.
                   </li>
                 <li>
                   Go to your email and accept the invitation to the organisation.

--- a/src/components/project-tabs/QRTab.jsx
+++ b/src/components/project-tabs/QRTab.jsx
@@ -227,57 +227,6 @@ const QRTab = (props) => {
             </Col>
           </Row>
         </Container>
-
-        {/* this is the instruction for the PC device */}
-        {/* <div id="instruction-div" className=""> */}
-        {/*  <h4 className="">QR Code Instructions</h4> */}
-        {/*  /!* <p>In order to successfully run the prototype, please do the following steps</p> *!/ */}
-        {/*  <span>To run this prototype on your device, do the following steps:</span> */}
-        {/*  <hr /> */}
-        {/*  <Form */}
-        {/*    // onSubmit={this.handleSubmit} */}
-        {/*    className="input-group navbar-group" */}
-        {/*    style={{margin: "",width:"50%"}} */}
-        {/*  > */}
-        {/*    <InputGroup className="input-group-prepend"> */}
-        {/*      <FormControl */}
-        {/*        className="form-control navbar-input" */}
-        {/*        aria-describedby="basic-addon1" */}
-        {/*        placeholder="Enter your Expo account email address" */}
-        {/*      /> */}
-        {/*      <InputGroup.Append> */}
-        {/*        <Button variant="btn btn-light search-button" type="submit"> */}
-        {/*          <img alt="search button" src={Search}/> */}
-        {/*        </Button> */}
-        {/*      </InputGroup.Append> */}
-        {/*    </InputGroup> */}
-        {/*  </Form> */}
-        {/*  <ol className="pc-ordered-list"> */}
-        {/*    /!*<p className="pc-ordered-list-p">To run this prototype on your device, do the following steps:</p>*!/ */}
-        {/*    <li> */}
-        {/*      Install the " */}
-        {/*      <a href="https://expo.io/tools">Expo Go</a> */}
-        {/*      " app on your mobile device. */}
-        {/*    </li> */}
-        {/*    <li>Sign into your Expo account, or create one if you don't already have one.</li> */}
-        {/*    <li>Add yourself to the ImagineThis Expo organisation by entering in your account's */}
-        {/*      email via the text box below</li> */}
-        {/*    <li>Go to your email and accept the invitation to the organisation. */}
-        {/*      If you are already a member you can skip this step.</li> */}
-        {/*    <li>Open your device's built-in camera app and point it at the QR code on this page</li> */}
-        {/*    <li>A notification will appear saying to open the build in Expo. Click on this.</li> */}
-        {/*    <li>The expo app should then open and the prototype should begin to run on your device.</li> */}
-        {/*  </ol> */}
-        {/* </div> */}
-
-        {/* <div id="qr-div"> */}
-        {/*  <a href={qrCodeLink}> */}
-        {/*    <QRCode className="qrcode" style={{ height: "150px", width: "150px", margin: "0px" }} value={qrCodeLink} /> */}
-        {/*  </a> */}
-        {/*  <div style={{textAlign: "center", marginLeft:"-22%"}}>Last build: {moment(lastConversion.timestamp).format("DD/MM/YY HH:mm")} by {lastConversion.userName}</div> */}
-        {/* </div> */}
-
-        {/* <div className="clear" /> */}
       </div>
 
       <div className="container d-block d-sm-none d-none d-sm-block d-md-none">
@@ -322,22 +271,20 @@ const QRTab = (props) => {
           </p>
           <Form
             onSubmit={sendEmail}
-            className="input-group navbar-group"
-            style={{ margin: "auto", width: "90%" }}
+            className="input-group mobile-input-bar-group"
           >
             <InputGroup className="input-group-prepend">
               <FormControl
-                // ref={inputEl}
-                style={{ fontSize: "12px" }}
-                className="form-control md-4"
+                ref={inputEl}
+                className="form-control md-4 mobile-input-bar"
                 aria-describedby="basic-addon1"
                 placeholder="Enter Expo Account Email Address"
               />
-              {/*<InputGroup.Append>*/}
-              {/*  <Button variant="btn btn-light search-button" type="submit">*/}
-              {/*    <img alt="search button" src={Search} />*/}
-              {/*  </Button>*/}
-              {/*</InputGroup.Append>*/}
+              <InputGroup.Append>
+                <Button type="submit" className="mobile-input-bar-button">
+                  Submit
+                </Button>
+              </InputGroup.Append>
             </InputGroup>
           </Form>
         </div>

--- a/src/css/guidebar.css
+++ b/src/css/guidebar.css
@@ -12,10 +12,11 @@
     padding-bottom: 0px;
 }
 
-/*.navbar-input-group{*/
-/*    margin-left:2px;*/
-/*    padding-left: 5px;*/
-/*}*/
+/*Makes it so buttons are in background when modal is shown. */
+.input-group-append{
+    z-index: 0;
+}
+
 
 /*For mobile view to take up full width of screen.*/
 @media screen and (min-width: 992px) {

--- a/src/css/project-tabs/QRtab.css
+++ b/src/css/project-tabs/QRtab.css
@@ -45,6 +45,21 @@ p{
     margin: auto;
 }
 
+.pc-input-bar-group{
+    width: 55%;
+    margin-left: 4%;
+    margin-bottom: 1%;
+
+}
+.pc-input-bar{
+    font-size: 14px;
+    height: 100%;
+}
+
+.pc-input-bar:focus{
+    /*border: none;*/
+}
+
 .clear{
     clear: both;
 }
@@ -86,4 +101,5 @@ p{
     display: inline-block;
     margin-left: 30px;
 }
+
 

--- a/src/css/project-tabs/QRtab.css
+++ b/src/css/project-tabs/QRtab.css
@@ -49,8 +49,8 @@ p{
     width: 55%;
     margin-left: 4%;
     margin-bottom: 1%;
-
 }
+
 .pc-input-bar{
     font-size: 14px;
     height: 100%;
@@ -62,6 +62,21 @@ p{
 
 .clear{
     clear: both;
+}
+
+.mobile-input-bar-group{
+    margin: auto;
+    width: 100%;
+
+}
+
+.mobile-input-bar{
+    font-size: 12px;
+    height: 100%;
+}
+
+.mobile-input-bar-button{
+    font-size: 12px;
 }
 
 .mobile-qr{


### PR DESCRIPTION
Everything nearly works, but there is one problem.

Currently, it's not possible to submit from either the desktop view and the mobile. You have to pick one and disable the other. The reason for this, I believe, is that`ref={inputEl}` appears in two different places. Because of this, only the last place it appears will have working code, the previous occurrence (desktop view) won't work.

I think it possible to fix this just by duplicating the function and split `inputEl` into two different variables, and have one variable for each function. Other than that, the branch is ready to merge. 