### PR TITLE
oauth functionality fix

### DIFF
--- a/src/consts.js
+++ b/src/consts.js
@@ -1,8 +1,10 @@
 /** deployed version */
 // export const DOMAIN = "http://88.80.186.99";
 export const DOMAIN = process.env.REACT_APP_DOMAIN;
-export const CLIENT_ID = "ZSjQ3iai2GyJYhAXq1fI2D";
-export const CLIENT_SECRET = "64wrt6gPjuFdsnZCtpKj29ZQcjpvVN";
+// export const CLIENT_ID = "ZSjQ3iai2GyJYhAXq1fI2D";
+export const CLIENT_ID = process.env.REACT_APP_CLIENT_ID;
+// export const CLIENT_SECRET = "64wrt6gPjuFdsnZCtpKj29ZQcjpvVN";
+export const CLIENT_SECRET = process.env.REACT_APP_CLIENT_SECRET;
 export const BACKEND_ADDRESS = process.env.REACT_APP_BACKEND_ADDRESS;
 export const LOCAL_HOST = "http://localhost:8080";
 


### PR DESCRIPTION
get Figma secret key and client ID from environment variables

old secret and ID are commented out, make sure to modify the local `.env` file:
```
REACT_APP_CLIENT_ID=""
REACT_APP_CLIENT_SECRET=""
```

to enable oauth on local development server